### PR TITLE
Add sample to ensure subcomponents only use allowed bindings from parent component

### DIFF
--- a/dagger-spi-validations/app/build.gradle
+++ b/dagger-spi-validations/app/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     implementation "com.google.dagger:dagger-android-support:2.26"
     kapt "com.google.dagger:dagger-android-processor:2.26"
 
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
+
     kapt project(":dagger-validator")
 
     testImplementation 'junit:junit:4.12'

--- a/dagger-spi-validations/app/src/main/java/dev/arunkumar/dagger/spi/validation/MainActivity.kt
+++ b/dagger-spi-validations/app/src/main/java/dev/arunkumar/dagger/spi/validation/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import dagger.Provides
 import dagger.android.ContributesAndroidInjector
 import dagger.android.support.DaggerAppCompatActivity
+import dev.arunkumar.dagger.spi.validation.di.ActivityScope
 import javax.inject.Inject
 
 class MainActivity : DaggerAppCompatActivity() {
@@ -14,6 +15,9 @@ class MainActivity : DaggerAppCompatActivity() {
     @Inject
     @JvmField
     var count: Int = 0
+
+    @Inject
+    lateinit var presenter: Presenter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -28,6 +32,7 @@ class MainActivity : DaggerAppCompatActivity() {
 
     @dagger.Module
     interface Builder {
+        @ActivityScope
         @ContributesAndroidInjector(modules = [Module::class])
         fun mainActivity(): MainActivity
     }

--- a/dagger-spi-validations/app/src/main/java/dev/arunkumar/dagger/spi/validation/Presenter.kt
+++ b/dagger-spi-validations/app/src/main/java/dev/arunkumar/dagger/spi/validation/Presenter.kt
@@ -1,0 +1,12 @@
+package dev.arunkumar.dagger.spi.validation
+
+import dev.arunkumar.dagger.spi.validation.di.ActivityScope
+import kotlinx.coroutines.CoroutineScope
+import javax.inject.Inject
+
+@ActivityScope
+class Presenter
+@Inject
+constructor(
+    private val scope: CoroutineScope
+)

--- a/dagger-spi-validations/app/src/main/java/dev/arunkumar/dagger/spi/validation/di/ActivityScope.kt
+++ b/dagger-spi-validations/app/src/main/java/dev/arunkumar/dagger/spi/validation/di/ActivityScope.kt
@@ -1,0 +1,6 @@
+package dev.arunkumar.dagger.spi.validation.di
+
+import javax.inject.Scope
+
+@Scope
+annotation class ActivityScope

--- a/dagger-spi-validations/app/src/main/java/dev/arunkumar/dagger/spi/validation/di/AppComponent.kt
+++ b/dagger-spi-validations/app/src/main/java/dev/arunkumar/dagger/spi/validation/di/AppComponent.kt
@@ -3,15 +3,27 @@ package dev.arunkumar.dagger.spi.validation.di
 import android.content.Context
 import dagger.BindsInstance
 import dagger.Component
+import dagger.Module
+import dagger.Provides
 import dagger.android.AndroidInjector
 import dagger.android.support.AndroidSupportInjectionModule
 import dev.arunkumar.dagger.spi.validation.MainActivity
 import dev.arunkumar.dagger.spi.validation.SpiValidation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 import javax.inject.Singleton
+
+@Module
+object AppModule {
+    @Provides
+    @Singleton
+    fun globalScope(): CoroutineScope = GlobalScope
+}
 
 @Singleton
 @Component(
     modules = [
+        AppModule::class,
         MainActivity.Builder::class,
         AndroidSupportInjectionModule::class
     ]


### PR DESCRIPTION
In this example `AppComponent` has `GlobalScope`, this check prevents sub scoped (Activity scoped) classes from injecting global coroutine scope accidentally. 

Example error:

```java
dagger-spi-validations/app/build/tmp/kapt3/stubs/debug/dev/arunkumar/dagger/spi/validation/di/AppComponent.java:8: error: [dev.arunkumar.dagger.validator.TridentValidator] Activity scoped bindings must not use global coroutine scope
public abstract interface AppComponent extends dagger.android.AndroidInjector<dev.arunkumar.dagger.spi.validation.SpiValidation> {
                ^
      dev.arunkumar.dagger.spi.validation.Presenter is injected at
          dev.arunkumar.dagger.spi.validation.MainActivity.presenter
      dev.arunkumar.dagger.spi.validation.MainActivity is injected at
          dagger.android.AndroidInjector.inject(T) [dev.arunkumar.dagger.spi.validation.di.AppComponent → dev.arunkumar.dagger.spi.validation.MainActivity_Builder_MainActivity.MainActivitySubcomponent]
FAILURE: Build failed with an exception.
```

Alternative
- Use component with dependencies to explicitly declare what can be shared.